### PR TITLE
Adding healthcheck + start on health check

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -44,7 +44,6 @@ jobs:
 
         # start the stack
         docker compose up --build -d
-        sleep 10
 
         # deploy static files and migrate database
         docker compose run django python manage.py collectstatic --no-input

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       cache_from:
         - opengisch/signalo-oapif:latest
     restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
     volumes:
       - static_volume:/static_volume
       - media_volume:/media_volume
@@ -42,6 +45,11 @@ services:
     image: postgis/postgis:13-3.1
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     ## UNCOMMENT IF YOU NEED THE POSTGIS DATABASE TO BE ACCESSIBLE
     # ports:
     # - 5432:5432


### PR DESCRIPTION
In many contexts (i.e. locally) services that depend on db services fail when the db service is not ready by the time the depending service makes a request to it. This PR suggests to use a healthcheck to avoid that this happens.
