### PR TITLE
Fixing typo in 'init' command

### DIFF
--- a/src/signalo/core/management/commands/init.py
+++ b/src/signalo/core/management/commands/init.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         }
 
         for k, command in controller.items():
-            if not options or k in options:
+            if not options or options[k]:
                 command()
 
         print(f"🎉 All set up!")


### PR DESCRIPTION
Fixing error that previously had all possible commands run instead of only those referenced as named arguments.