### PR TITLE
Fixed Django not hot-reloading; added persistent pgresdata

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,11 +46,11 @@ jobs:
         docker compose up --build -d
 
         # deploy static files and migrate database
-        docker compose run django python manage.py collectstatic --no-input
-        docker compose run django python manage.py migrate --no-input
+        docker compose exec django python manage.py collectstatic --no-input
+        docker compose exec django python manage.py migrate --no-input
 
         # sprinkle some test data (refreshing computed fields is done from the command handler)
-        docker compose run django python manage.py init --data --users
+        docker compose exec django python manage.py init --data --users
 
     - name: Healthcheck
       run: wget --no-check-certificate https://localhost/oapif/collections/signalo_core.pole/items

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ cp .env.example .env
 docker compose up --build -d
 
 # deploy static files and migrate database
-docker compose run django python manage.py collectstatic --no-input
-docker compose run django python manage.py migrate --no-input
+docker compose exec django python manage.py collectstatic --no-input
+docker compose exec django python manage.py migrate --no-input
 
 # A convenience start-up Django command is there to help you get started with testdata
 # and users; call it without argument to let it populate the database with testdata, users and a superuser:
-docker compose run django python manage.py init
+docker compose exec django python manage.py init
 
 # Alternatively pass it any combination of the following options: --data, --users, --superuser
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
     ## UNCOMMENT IF YOU NEED THE POSTGIS DATABASE TO BE ACCESSIBLE
     # ports:
     # - 5432:5432
@@ -59,3 +61,4 @@ volumes:
   static_volume:
   media_volume:
   caddy_data:
+  postgres_data:


### PR DESCRIPTION
Changes under `src` needed a full restart of the Compose stack to apply (unless one used `docker compose exec`). Doing a full restart of the Compose stack would destroy the database storage. Unfortunate combination. This fixes it. (Also we don't need to run `run` when we can `exec`).